### PR TITLE
Make regexes for identifying ZSK/KSK more strict

### DIFF
--- a/scripts/configure_child.sh
+++ b/scripts/configure_child.sh
@@ -135,7 +135,7 @@ for subdomain in ${subdomains[@]}; do
     if [[ $subdomain = "no-zsk" ]]; then
         # Find numbers of lines where the key is located
         line_start=$(grep -n 'DNSKEY.*256' $output_dir/db.$zone.signed | cut -f1 -d:)
-        line_end=$(grep -n 'ZSK' $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_end=$(grep -n ' ZSK;' $output_dir/db.$zone.signed | cut -f1 -d:)
         sed -i "${line_start},${line_end}d" $output_dir/db.$zone.signed
     # Edit the part of the ZSK
     elif [[ $subdomain = "bad-zsk" ]]; then
@@ -164,7 +164,7 @@ for subdomain in ${subdomains[@]}; do
     elif [[ $subdomain = "no-ksk" ]]; then
         # Find numbers of lines where the key is located
         line_start=$(grep -n 'DNSKEY.*257' $output_dir/db.$zone.signed | cut -f1 -d:)
-        line_end=$(grep -n 'KSK' $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_end=$(grep -n ' KSK;' $output_dir/db.$zone.signed | cut -f1 -d:)
         sed -i "${line_start},${line_end}d" $output_dir/db.$zone.signed
     fi
 


### PR DESCRIPTION
I'm working on adapting the zone configuration scripts for use in offline tests (see hickory-dns/hickory-dns#2491) and I noticed that the commands for a couple zones may fail intermittently. The issue is that searching for `ZSK` or `KSK` to find the end of a DNSKEY may return a false positive match inside base64-encoded public keys. In such cases, `line_end` contains two numbers separated by a newline. The newline gets included in the sed script, which causes an error, and prevents deletion of the desired key from the signed zone file. This PR fixes the issue by matching a space and a semicolon on either end of the pattern, to prevent matching on base64 text. I figure this robustness improvement may help with the periodic maintenance of the `extended-dns-errors.com` zone files.